### PR TITLE
Add stex.sentry initializer

### DIFF
--- a/lib/initializers/sentry.js
+++ b/lib/initializers/sentry.js
@@ -1,0 +1,10 @@
+var Initializer = require("../initializer");
+
+Initializer.add('startup', 'stex.sentry', ['stex.config'], function(stex) {
+  var sentryDsn = stex.conf.get("sentryDsn"); || false;
+
+  if (sentryDsn) {
+    var raven = require('raven');
+    stex.sentry = new raven.Client(SENTRY_DSN);
+  }
+});


### PR DESCRIPTION
- Adds sentry initializer to stex
- stex.sentry returns a raven client with the sentry dsn config
