### PR TITLE
Autoload models first

### DIFF
--- a/lib/initializers/autoload.js
+++ b/lib/initializers/autoload.js
@@ -5,8 +5,8 @@ var _           = require("lodash");
 var Inflector   = require("inflected");
 
 Initializer.add('startup', 'stex.autoload', ['stex.express'], function(stex) {
-  stex.controllers = autoload(path.join(stex.root, "lib", "controllers"));
   stex.models      = autoload(path.join(stex.root, "lib", "models"));  
+  stex.controllers = autoload(path.join(stex.root, "lib", "controllers"));
 });
 
 function autoload(root) {


### PR DESCRIPTION
This PR changes the autoload order from "controller then models" to "models then controllers".  It allows us to more easily use models in our controllers by allowing us to do the following at any location in the controller js file:

```javascript

let { User, Invite } = stex.models;

```
