### PR TITLE
Better initializers

### DIFF
--- a/lib/initializer.js
+++ b/lib/initializer.js
@@ -6,14 +6,21 @@ var Promise    = require("bluebird");
 var requireAll = require("./util/require-all");
 
 
-var Initializer = function(name, dep, fun) {
-  if(typeof fun === 'undefined') {
-    fun = dep;
-    dep = [];
+var Initializer = function(name) {
+  this.name = name;
+  this.dep = [];
+  this.fun = null;
+};
+
+Initializer.prototype.addDep = function(name) {
+  this.dep.push(name);
+};
+
+Initializer.prototype.setFun = function(fun) {
+  if(this.fun) {
+    throw new Error("Cannot overwrite initializer function for: " + this.name);
   }
 
-  this.name = name;
-  this.dep = dep;
   this.fun = fun;
 };
 
@@ -23,7 +30,38 @@ Initializer.registered = {
 };
 
 Initializer.add = function(phase, name, dep, fun) {
-  Initializer.registered[phase][name] = new Initializer(name, dep, fun);
+  var before, after;
+
+  if (typeof fun === 'undefined') {
+    fun = dep;
+    dep = [];
+  }
+
+  if (_.isPlainObject(dep)) {
+    before = dep.before || [];
+    after = dep.after || [];
+  } else {
+    after = dep || [];
+  }
+
+  var init = Initializer.get(phase, name);
+
+  _.each(after, function(dep) { init.addDep(dep); });
+  _.each(before, function(dep) { Initializer.get(phase, dep).addDep(name); });
+
+  init.setFun(fun);
+
+  return init;
+};
+
+Initializer.get = function(phase, name) {
+  var init = Initializer.registered[phase][name];
+
+  if(!init) {
+    init = Initializer.registered[phase][name] = new Initializer(name);
+  }
+
+  return init;
 };
 
 // util functions
@@ -48,12 +86,16 @@ Initializer.run = function(stex, phase) {
   });
 
   var runInitializer = function(initializer) {
+    if(!initializer.fun) {
+      return Promise.resolve();
+    }
+    
     return initializer.fun.call(null, stex);
   };
 
   var reducer = function(prev, initializer) {
     return prev.then(function() {
-      return initializer.fun.call(null, stex);
+      return runInitializer(initializer);
     });
   };
 

--- a/lib/util/errors.js
+++ b/lib/util/errors.js
@@ -15,12 +15,12 @@ Error.subclass = function(errorName) {
 Error.prototype.setCode = function(code) {
   this.code = code;
   return this;
-}
+};
 
 Error.prototype.setData = function(data) {
   this.data = data;
   return this;
-}
+};
 
 var errors = module.exports;
 


### PR DESCRIPTION
This PR adds support for specifying dependencies amongst Intializers with an object, such that:

```javascript
Initializer.add('startup', 'stex.system1', function(){ console.log("system1"); });
Initializer.add('startup', 'stex.system2', {before:['stex.system3'], after:['stex.system1']}, function(){ console.log("system2"); });
Initializer.add('startup', 'stex.system3', ['stex.systsem1'], function(){ console.log("system3"); });
```

Notice, you can specify an object for dependencies, using `before` and `after` keys to express ordering.