### PR TITLE
Quick fix to exit after stex migrate finishes it's job

### DIFF
--- a/bin/stex
+++ b/bin/stex
@@ -150,6 +150,7 @@ program
     })
     .finally(function () {
       stex.shutdown();
+      process.exit(0);
     })
   });
 


### PR DESCRIPTION
Not sure why exactly but stex doesn't exit after running `stex migrate` and because of this travis don't continue to the next task in stellar-api. As far as I understand it's a legacy code (`db-migrate` is a newer version) so I decided to apply this quick fix. We probably also want to change migration gulp task in stellar-api from `db:migrate-knex` to `db:migrate`.