### PR TITLE
Revert "Quick fix to exit after stex migrate finishes it's job"

### DIFF
--- a/bin/stex
+++ b/bin/stex
@@ -150,7 +150,6 @@ program
     })
     .finally(function () {
       stex.shutdown();
-      process.exit(0);
     })
   });
 


### PR DESCRIPTION
Reverts stellar/stex#40

Sorry, a problem was with `express-brute-redis` in my repo.