### PR TITLE
Capitalize autoloaded modules

### DIFF
--- a/lib/initializers/autoload.js
+++ b/lib/initializers/autoload.js
@@ -41,6 +41,7 @@ function objectFromModulePath(modulePath, exports) {
   return _.reduce(reverseModulePath, function(current, modulePathComponent) {
     var next = {};
     next[modulePathComponent] = current;
+    next[Inflector.camelize(modulePathComponent)] = current;
     return next;
   }, exports);
 }


### PR DESCRIPTION
This PR adds capitalized modules names while autoloading. To not break existing apps we leave existing [camelized](https://github.com/martinandert/inflected#inflectorcamelize) (with `uppercaseFirstLetter` = `false`) module names. They will be removed after all apps migrate to a newer stex version.

See discussion: https://github.com/stellar/stellar-api/pull/42#discussion_r25180447 