### PR TITLE
Rename heapdump extension

### DIFF
--- a/lib/initializers/heapdump.js
+++ b/lib/initializers/heapdump.js
@@ -14,7 +14,7 @@ Initializer.add('startup', 'stex.heapdump', function(stex) {
 
   
   process.on('SIGUSR2', function() {
-    fileName = "pid-" + process.pid + "-" + (new Date().toISOString()) + ".heapdump";
+    fileName = "pid-" + process.pid + "-" + (new Date().toISOString()) + ".heapsnapshot";
     dumpPath = path.join(heapDir, fileName);
     heapdump.writeSnapshot(dumpPath);
   });


### PR DESCRIPTION
Chrome only allows you to open them if they're named `.heapsnapshot`