### PR TITLE
Add timestamp, date, and requestId to logs

### DIFF
--- a/lib/initializers/errors.js
+++ b/lib/initializers/errors.js
@@ -8,7 +8,7 @@ Initializer.add('startup', 'stex.errors', ['stex.initialize-app', 'stex.cls'], f
 
   /// catch 404 and forwarding to error handler
   stex.app.use(function(req, res, next) {
-    res.send(404, {
+    res.status(404).send({
       "status": "fail",
       "code":   "not_found"
     });

--- a/lib/util/json-log-humanizer.js
+++ b/lib/util/json-log-humanizer.js
@@ -4,37 +4,32 @@ var _         = require('lodash');
 
 var typeProcessors = {};
 typeProcessors.message = function(data) {
-  return data.message;
+  return data.message + extraData(data);
 };
 
 typeProcessors.request = function(data) {
-  var requestLine = data.method + " " + data.url;
+  var requestLine = data.method + " " + data.url + extraData(data);
   var bodyJson    = JSON.stringify(data.body, null, 2);
   return requestLine + "\n" + bodyJson;
 };
 
 typeProcessors.response = function(data) {
-  var statusText = http.STATUS_CODES[data.status];
+  var statusText = http.STATUS_CODES[data.status] + extraData(data);
 
   return data.status + " " + statusText + " (" + data.duration.toFixed(3) + "ms)";
 };
 
 typeProcessors.error = function(data) {
-  var initialLine = data.error.className + ": " + data.error.message;
+  var initialLine = data.error.className + ": " + data.error.message + extraData(data);
   var stackLines  = _.map(data.error.stack, function(line) {
                       return "  " + line;
                     }).join("\n");
-  var extras = "  {\n";
-  extras += "    'timestamp': " + data.timestamp + "\n";
-  extras += "    'date': " + data.date + "\n";
-  extras += "    'request-id': " + data.requestId + "\n";
-  extras += "  }";
-  return initialLine + "\n" + extras + "\n" + stackLines;
+  return initialLine + "\n" + stackLines;
 };
 
 typeProcessors.query = function(data) {
   //TODO: figure out how to get timing info from knex
-  return "SQL: " + data.sql;
+  return "SQL: " + data.sql + extraData(data);
 };
 
 humanizer.target = function(options, severity, date, message) {
@@ -53,6 +48,19 @@ humanizer.processLine = function(line) {
   }
 };
 
+function extraData(data) {
+  var extras = "";
+  if (data.timestamp) {
+    extras += " timestamp: " + data.timestamp;
+  }
+  if (data.date) {
+    extras += " date: " + data.date;
+  }
+  if (data.requestId) {
+    extras += " requestId: " + data.requestId;
+  }
+  return extras;
+}
 
 function defaultProcessor(data) {
   return JSON.stringify(data, null, 2);


### PR DESCRIPTION
This was requested by @matschaffer to make cursory log parsing in the prod stdout logs in stellar-api easier. 

I'm not convinced, by the nature of what the json-humanizer is trying to accomplish, that this is the best place for this "extra" information. Alternatively, there should be another target which doesn't "humanize" the logs, but rather logs all available information from a rich log object to JSON in another file or to a service such as Loggly or something.

@nullstyle @matschaffer thoughts?